### PR TITLE
Add caching for downloads and extractions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The application features real-time progress updates, an integrated user authenti
 
 - **YouTube Integration**: Search and discover YouTube content
 - **Download Management**: Queue-based download system with progress tracking
+- **Smart Caching**: Existing downloads and stem extractions are reused
 - **Stem Extraction**: AI-powered audio separation using Demucs
 - **Interactive Mixer**: Visual waveform display with audio controls
 - **User Authentication**: Multi-user support with role-based access
@@ -127,6 +128,7 @@ Manages the download queue and handles video/audio download operations.
 - `DownloadItem`: Data structure for download tasks
 - `DownloadType`: Enum for download types (AUDIO/VIDEO)
 - `DownloadStatus`: Enum for download states
+- Skips download if the target file already exists
 
 ### 3. Stems Extractor (core/stems_extractor.py)
 
@@ -136,6 +138,7 @@ Handles the extraction of audio stems from downloaded tracks.
 - `StemsExtractor`: Main class for extraction operations
 - `ExtractionItem`: Data structure for extraction tasks
 - `ExtractionStatus`: Enum for extraction states
+- Reuses existing stem files if found in the output directory
 
 ### 4. YouTube Client (core/aiotube_client.py)
 
@@ -242,6 +245,7 @@ stemtubes-web/
 ├── app.py                  # Main Flask application
 ├── requirements.txt        # Python dependencies
 ├── stemtubes.db            # SQLite database
+├── processed.db            # Cache of processed files
 │
 ├── core/                   # Core Python modules
 │   ├── __init__.py

--- a/core/processed_db.py
+++ b/core/processed_db.py
@@ -1,0 +1,83 @@
+import os
+import sqlite3
+from typing import Optional
+
+DB_PATH = os.path.join(os.path.dirname(__file__), 'processed.db')
+
+
+def _get_conn():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db():
+    conn = _get_conn()
+    try:
+        conn.execute("CREATE TABLE IF NOT EXISTS downloads (video_id TEXT PRIMARY KEY, file_path TEXT)")
+        conn.execute("CREATE TABLE IF NOT EXISTS extractions (audio_hash TEXT PRIMARY KEY, output_dir TEXT)")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# --------- Download helpers ---------
+
+def get_download_path(video_id: str) -> Optional[str]:
+    conn = _get_conn()
+    try:
+        row = conn.execute("SELECT file_path FROM downloads WHERE video_id=?", (video_id,)).fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
+def save_download_path(video_id: str, file_path: str):
+    conn = _get_conn()
+    try:
+        conn.execute("REPLACE INTO downloads (video_id, file_path) VALUES (?, ?)", (video_id, file_path))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def remove_download(video_id: str):
+    conn = _get_conn()
+    try:
+        conn.execute("DELETE FROM downloads WHERE video_id=?", (video_id,))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# --------- Extraction helpers ---------
+
+def get_extraction_dir(audio_hash: str) -> Optional[str]:
+    conn = _get_conn()
+    try:
+        row = conn.execute("SELECT output_dir FROM extractions WHERE audio_hash=?", (audio_hash,)).fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
+def save_extraction_dir(audio_hash: str, output_dir: str):
+    conn = _get_conn()
+    try:
+        conn.execute("REPLACE INTO extractions (audio_hash, output_dir) VALUES (?, ?)", (audio_hash, output_dir))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def remove_extraction(audio_hash: str):
+    conn = _get_conn()
+    try:
+        conn.execute("DELETE FROM extractions WHERE audio_hash=?", (audio_hash,))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# Initialize database on module load
+init_db()


### PR DESCRIPTION
## Summary
- detect existing downloaded files before starting a download
- reuse previously extracted stems when present
- add `processed.db` to cache download and extraction paths
- document caching behaviour

## Testing
- `python -m py_compile core/download_manager.py core/stems_extractor.py core/processed_db.py`

------
https://chatgpt.com/codex/tasks/task_e_684b534f719c832c8e5406ff979cf5f0