### PR TITLE
Refactor download route compatibility

### DIFF
--- a/app.py
+++ b/app.py
@@ -892,10 +892,11 @@ def open_folder_route():
 
 @app.route('/api/download-file', methods=['GET'])
 @api_login_required
-def download_file_route():
+def download_file_route(file_path=None):
     """Download a file."""
     try:
-        file_path = request.args.get('file_path')
+        if file_path is None:
+            file_path = request.args.get('file_path')
         
         if not file_path or not os.path.exists(file_path):
             return jsonify({
@@ -936,13 +937,8 @@ def download_file_route():
 @api_login_required
 def download_file_compatible():
     """Route compatible pour le téléchargement de fichiers."""
-    # Convertir path en file_path
     path = request.args.get('path')
-    if path:
-        request.args = request.args.copy()
-        request.args = dict(request.args)
-        request.args['file_path'] = path
-    return download_file_route()
+    return download_file_route(file_path=path)
 
 @app.route('/api/test_stems/<stem_file>', methods=['GET'])
 @api_login_required


### PR DESCRIPTION
## Summary
- remove manipulation of `request.args` in compatibility endpoint
- allow `download_file_route` to accept an optional file path

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684b56642fa8832ca212448dd730aec3