### PR TITLE
Fix README download endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Modular components for the audio mixing interface.
 
 ### File Operations
 
-- `GET /api/download_file/:id`: Download processed file
+- `GET /api/download-file?file_path=...`: Download processed file. Provide the target file path in the `file_path` query parameter.
 - `GET /api/waveform`: Generate waveform data
 - `POST /api/export_mix`: Create mixdown of modified stems
 


### PR DESCRIPTION
## Summary
- update file download endpoint in API docs

## Testing
- `python -m py_compile app.py`
- `find core -name '*.py' -print | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_684b56662f60832c8ac96bb6b9e6f3e9